### PR TITLE
switch hyphens for underscores

### DIFF
--- a/prereceivecli/lib/utils.py
+++ b/prereceivecli/lib/utils.py
@@ -196,7 +196,7 @@ def get_table_for_project_group(project_group, credentials):
     except NoRegionError:
         LOGGER.exception('')
         raise ValueError(invalid_settings)
-    project_group = project_group.replace('/', '_')
+    project_group = project_group.replace('/', '_').replace('-', '_')
     table = dynamodb.Table(f'{project_group}_git_hook')
     try:
         table.item_count


### PR DESCRIPTION
the current pre-receive project logic results in a crime against humanity if underscores are in the name of the subgroup.
parentgroup_my-project-name_slug

