### PR TITLE
Disregard refs with all zeroes

### DIFF
--- a/prereceivecli/prereceivecli.py
+++ b/prereceivecli/prereceivecli.py
@@ -287,6 +287,12 @@ def main():
             LOGGER.info('It seems only tags were pushed for project "%s" by username "%s", letting through',
                         project.slug, project.username)
             raise SystemExit(0)
+        # In some cases (e.g. if a branch is deleted), incoming commit (newrev) is
+        # 0000000000000000000000000000000000000000 on which we cannot do any meaningful checks
+        if commit.isdecimal() and int(commit) == 0:
+            LOGGER.info('Disregarding push with newrev="%s" for project "%s" by username "%s", '
+                        'letting through', commit, project.slug, project.username)
+            raise SystemExit(0)
         os.environ['AWS_DEFAULT_REGION'] = args.region
         dynamodb_table = get_table_for_project_group(project.group, get_credentials(args))
         if not dynamodb_table:


### PR DESCRIPTION
In some cases (e.g. if a branch is deleted), the incoming commit (newrev) is `0000000000000000000000000000000000000000` on which we cannot do any meaningful checks.

Currently this breaks with the following exception:
```
2021-03-22 17:06:01,871 - utils.HashChecker - ERROR - Error executing command "['/usr/local/libexec/git-core/git', 'archive', '--format=zip', '-o', '/tmp/tmp17eosh3g/archive.zip', '-0', '0000000000000000000000000000000000000000']"
	stderr: "b'fatal: not a tree object: 0000000000000000000000000000000000000000\n'"
	stdout: "b''"
```

This PR handles the all-zero ref by returning early.